### PR TITLE
Fix scripts so pages render

### DIFF
--- a/public/js/auth/auth.js
+++ b/public/js/auth/auth.js
@@ -11,39 +11,7 @@ const showMessage = (modalId, type, message) => {
   }, 3000)
 }
 
-const storage = {
-  users: [],
-  currentUser: null,
-
-  findUserByEmail(email) {
-    return this.users.find((user) => user.email === email)
-  },
-
-  addUser(user) {
-    this.users.push(user)
-    return user
-  },
-
-  authenticateUser(email, password) {
-    const user = this.findUserByEmail(email)
-    if (user && user.password === password) {
-      return user
-    }
-    return null
-  },
-
-  setCurrentUser(user) {
-    this.currentUser = user
-  },
-
-  clearCurrentUser() {
-    this.currentUser = null
-  },
-
-  getCurrentUser() {
-    return this.currentUser
-  },
-}
+const storage = window.storage
 
 const switchToLogin = () => {
   document.getElementById("registerModal").style.display = "none"
@@ -74,13 +42,6 @@ const updateCartDisplay = () => {
   }
 }
 
-const showSection = (sectionId) => {
-  const sections = document.querySelectorAll(".section")
-  sections.forEach((section) => {
-    section.style.display = "none"
-  })
-  document.getElementById(sectionId).style.display = "block"
-}
 
 function handleRegister(event) {
   event.preventDefault()
@@ -174,7 +135,7 @@ function handleLogout() {
     updateCartDisplay()
 
     // Show home section
-    showSection("home")
+    window.showSection("home")
 
     alert("You have been logged out successfully.")
   }
@@ -200,3 +161,9 @@ function updateUserInterface() {
     userMenu.style.display = "none"
   }
 }
+
+// Expose auth functions globally for inline event handlers
+window.handleRegister = handleRegister
+window.handleLogin = handleLogin
+window.handleLogout = handleLogout
+window.updateUserInterface = updateUserInterface

--- a/public/js/cart/cart.js
+++ b/public/js/cart/cart.js
@@ -1,8 +1,7 @@
-// Import necessary modules
-const storage = require("./storage")
-const { openModal } = require("./modal")
-const animals = require("./animals")
-const { updateCartDisplay } = require("./cartDisplay")
+// Access globals provided by other scripts
+const storage = window.storage
+const animals = window.animals
+const { openModal } = window
 
 // Cart functionality
 function addToCart(animalId) {
@@ -119,3 +118,10 @@ For this demo, we'll clear your cart.`)
     updateCartDisplay()
   }
 }
+
+// Make cart functions globally accessible
+window.addToCart = addToCart
+window.removeFromCart = removeFromCart
+window.updateCartCount = updateCartCount
+window.proceedToAdoption = proceedToAdoption
+window.updateCartDisplay = updateCartDisplay

--- a/public/js/components/modals.js
+++ b/public/js/components/modals.js
@@ -64,3 +64,10 @@ function showMessage(modalId, type, message) {
     }
   }
 }
+
+// Expose functions globally for inline event handlers
+window.openModal = openModal
+window.closeModal = closeModal
+window.switchToLogin = switchToLogin
+window.switchToRegister = switchToRegister
+window.showMessage = showMessage

--- a/public/js/components/navigation.js
+++ b/public/js/components/navigation.js
@@ -39,22 +39,22 @@ function loadSection(sectionName) {
 
   switch (sectionName) {
     case "home":
-      content = "Home Content" // Placeholder for getHomeContent()
+      content = getHomeContent()
       break
     case "animals":
-      content = "Animals Content" // Placeholder for getAnimalsContent()
+      content = getAnimalsContent()
       break
     case "cart":
-      content = "Cart Content" // Placeholder for getCartContent()
+      content = getCartContent()
       break
     case "about":
-      content = "About Content" // Placeholder for getAboutContent()
+      content = getAboutContent()
       break
     case "contact":
-      content = "Contact Content" // Placeholder for getContactContent()
+      content = getContactContent()
       break
     default:
-      content = "Home Content" // Placeholder for getHomeContent()
+      content = getHomeContent()
   }
 
   mainContent.innerHTML = content
@@ -66,16 +66,20 @@ function loadSection(sectionName) {
 function initializeSection(sectionName) {
   switch (sectionName) {
     case "home":
-      console.log("Initializing Home Section") // Placeholder for initializeHome()
+      initializeHome()
       break
     case "animals":
-      console.log("Initializing Animals Section") // Placeholder for initializeAnimals()
+      initializeAnimals()
       break
     case "cart":
-      console.log("Initializing Cart Section") // Placeholder for initializeCart()
+      initializeCart()
       break
     case "contact":
-      console.log("Initializing Contact Section") // Placeholder for initializeContact()
+      initializeContact()
       break
   }
 }
+
+// Expose navigation functions globally
+window.showSection = showSection
+window.toggleMobileMenu = toggleMobileMenu

--- a/public/js/data/animals.js
+++ b/public/js/data/animals.js
@@ -103,3 +103,6 @@ const animals = [
     location: "Small Animal Room",
   },
 ]
+
+// Expose data globally so other scripts can access it
+window.animals = animals

--- a/public/js/pages/about.js
+++ b/public/js/pages/about.js
@@ -28,3 +28,6 @@ function getAboutContent() {
         </section>
     `
 }
+
+// Expose about page helper globally
+window.getAboutContent = getAboutContent

--- a/public/js/pages/animals.js
+++ b/public/js/pages/animals.js
@@ -168,3 +168,7 @@ Location: ${animal.location}`
 
   alert(detailText)
 }
+
+// Expose animals page helpers globally
+window.getAnimalsContent = getAnimalsContent
+window.initializeAnimals = initializeAnimals

--- a/public/js/pages/cart.js
+++ b/public/js/pages/cart.js
@@ -1,10 +1,5 @@
 // Cart page functionality
-const storage = {
-  getCart: () => {
-    // Mock implementation for demonstration purposes
-    return JSON.parse(localStorage.getItem("cart")) || []
-  },
-}
+const storage = window.storage
 
 function getCartContent() {
   return `
@@ -113,17 +108,8 @@ function updateCartDisplay() {
   console.log("Cart display updated successfully")
 }
 
-function showSection(sectionId) {
-  // Mock implementation for demonstration purposes
-  console.log(`Showing section: ${sectionId}`)
-}
+// Expose cart page helpers globally
+window.getCartContent = getCartContent
+window.initializeCart = initializeCart
+window.updateCartDisplay = updateCartDisplay
 
-function proceedToAdoption() {
-  // Mock implementation for demonstration purposes
-  console.log("Proceeding to adoption...")
-}
-
-function removeFromCart(itemId) {
-  // Mock implementation for demonstration purposes
-  console.log(`Removing item with ID: ${itemId}`)
-}

--- a/public/js/pages/contact.js
+++ b/public/js/pages/contact.js
@@ -90,3 +90,7 @@ function handleContactForm(e) {
   // Reset form
   e.target.reset()
 }
+
+// Expose contact page helpers globally
+window.getContactContent = getContactContent
+window.initializeContact = initializeContact

--- a/public/js/pages/home.js
+++ b/public/js/pages/home.js
@@ -147,14 +147,7 @@ function createAnimalCard(animal) {
     `
 }
 
-function viewAnimalDetail(id) {
-  // Implement view animal detail functionality
-}
+// Expose home page helpers globally
+window.getHomeContent = getHomeContent
+window.initializeHome = initializeHome
 
-function addToCart(id) {
-  // Implement add to cart functionality
-}
-
-function showSection(sectionId) {
-  // Implement show section functionality
-}

--- a/public/js/utils/storage.js
+++ b/public/js/utils/storage.js
@@ -95,3 +95,6 @@ class Storage {
 
 // Create global storage instance
 const storage = new Storage()
+
+// Make the storage instance available globally
+window.storage = storage


### PR DESCRIPTION
## Summary
- expose shared data and storage objects on `window`
- export modal helpers for global use
- hook cart helpers to the global scope
- connect navigation to page builders and initializers
- clean up page scripts to use shared globals
- update auth script to use shared storage

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68863ada435883308bf81fac8bf46d04